### PR TITLE
Fix a typo in index.html

### DIFF
--- a/monitor/templates/index.html
+++ b/monitor/templates/index.html
@@ -29,7 +29,7 @@
               <input type="hidden"
                   name="successRedirectUrl"
                   value="{{ url_for('main.thankyou') }}">
-              <button class="text-xl shadow-md font-medium bg-orange-500 hover:bg-orange-700 text-white sm:mt-2 md:mt-0 py-2 px-4 rounded">Tell me when it's aviable!</button>
+              <button class="text-xl shadow-md font-medium bg-orange-500 hover:bg-orange-700 text-white sm:mt-2 md:mt-0 py-2 px-4 rounded">Tell me when it's available!</button>
           </div>
       </div>
       </form>


### PR DESCRIPTION
aviable -> available
also the EOL GitHub created automatically.

[servermonitor-mockup-screely.png](https://github.com/ChristianLutzCL/ServerMonitor/blob/master/servermonitor-mockup-screely.png) should also be changed with the fixed word.